### PR TITLE
Fix building wheel for amara3.xml (pyproject.toml) for python 3.13

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
Hello @uogbuji 

I hope you're doing well!

We have a dependency on your project. I started to use Python 3.13 and I failed in `pip install -r ./requirements` step because of the next error:

> Building wheel for amara3.xml (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Building wheel for amara3.xml (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [66 lines of output]
      C:\Users\User\AppData\Local\Temp\pip-build-env-pnmh3pns\overlay\Lib\site-packages\setuptools\dist.py:599: SetuptoolsDeprecationWarning: Invalid dash-separated key 'description-file' in 'metadata' (setup.cfg), please use the underscore name 'description_file' instead.
      !!
      
              ********************************************************************************
              Usage of dash-separated 'description-file' will not be supported in future
              versions. Please use the underscore name 'description_file' instead.
              (Affected: amara3.xml).
      
              By 2026-Mar-03, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.
      
              See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
              ********************************************************************************
      
      !!
        opt = self._enforce_underscore(opt, section)
      C:\Users\User\AppData\Local\Temp\pip-build-env-pnmh3pns\overlay\Lib\site-packages\setuptools\dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!
      
              ********************************************************************************
              Please consider removing the following classifiers in favor of a SPDX license expression:
      
              License :: OSI Approved :: Apache Software License
      
              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************
      
      !!
        self._finalize_license_expression()
      running bdist_wheel
      running build
      running build_py
      creating build\lib.win-amd64-cpython-313\amara3\uxml
      copying pylib\uxml\coax.py -> build\lib.win-amd64-cpython-313\amara3\uxml
      copying pylib\uxml\html5.py -> build\lib.win-amd64-cpython-313\amara3\uxml
      copying pylib\uxml\html5iter.py -> build\lib.win-amd64-cpython-313\amara3\uxml
      copying pylib\uxml\lex.py -> build\lib.win-amd64-cpython-313\amara3\uxml
      copying pylib\uxml\parser.py -> build\lib.win-amd64-cpython-313\amara3\uxml
      copying pylib\uxml\tree.py -> build\lib.win-amd64-cpython-313\amara3\uxml
      copying pylib\uxml\treeiter.py -> build\lib.win-amd64-cpython-313\amara3\uxml
      copying pylib\uxml\treeutil.py -> build\lib.win-amd64-cpython-313\amara3\uxml
      copying pylib\uxml\version.py -> build\lib.win-amd64-cpython-313\amara3\uxml
      copying pylib\uxml\writer.py -> build\lib.win-amd64-cpython-313\amara3\uxml
      copying pylib\uxml\xml.py -> build\lib.win-amd64-cpython-313\amara3\uxml
      copying pylib\uxml\xmliter.py -> build\lib.win-amd64-cpython-313\amara3\uxml
      copying pylib\uxml\__init__.py -> build\lib.win-amd64-cpython-313\amara3\uxml
      creating build\lib.win-amd64-cpython-313\amara3\uxml\uxpath
      copying pylib\uxml\uxpath\ast.py -> build\lib.win-amd64-cpython-313\amara3\uxml\uxpath
      copying pylib\uxml\uxpath\functions.py -> build\lib.win-amd64-cpython-313\amara3\uxml\uxpath
      copying pylib\uxml\uxpath\lexrules.py -> build\lib.win-amd64-cpython-313\amara3\uxml\uxpath
      copying pylib\uxml\uxpath\parserules.py -> build\lib.win-amd64-cpython-313\amara3\uxml\uxpath
      copying pylib\uxml\uxpath\__init__.py -> build\lib.win-amd64-cpython-313\amara3\uxml\uxpath
      running build_ext
      building 'amara3.cmodules.cxmlstring' extension
      creating build\temp.win-amd64-cpython-313\Release\clib
      "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.37.32822\bin\HostX86\x64\cl.exe" /c /nologo /O2 /W3 /GL /DNDEBUG /MD -Iclib -IC:\Users\User\projects\translate\.venv\include -IC:\Users\User\apps\python13\include -IC:\Users\User\apps\python13\Include "-IC:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.37.32822\include" "-IC:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\VS\include" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\um" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\shared" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\winrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\cppwinrt" /Tcclib/xmlstring.c /Fobuild\temp.win-amd64-cpython-313\Release\clib\xmlstring.obj
      xmlstring.c
      clib/xmlstring.c(53): warning C4996: 'Py_UNICODE': deprecated in 3.13
      clib/xmlstring.c(114): warning C4013: 'PyUnicode_AS_UNICODE' undefined; assuming extern returning int
      clib/xmlstring.c(114): warning C4047: '=': 'Py_UNICODE *' differs in levels of indirection from 'int'
      creating C:\Users\User\AppData\Local\Temp\pip-install-fzl8mr3o\amara3-xml_f5c71c7e3e124946b388ca0ef23d465a\build\lib.win-amd64-cpython-313\amara3\cmodules
      "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.37.32822\bin\HostX86\x64\link.exe" /nologo /INCREMENTAL:NO /LTCG /DLL /MANIFEST:EMBED,ID=2 /MANIFESTUAC:NO /LIBPATH:C:\Users\User\projects\translate\.venv\libs /LIBPATH:C:\Users\User\apps\python13\libs /LIBPATH:C:\Users\User\apps\python13 /LIBPATH:C:\Users\User\projects\translate\.venv\PCbuild\amd64 "/LIBPATH:C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.37.32822\lib\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\lib\10.0.22621.0\ucrt\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\\lib\10.0.22621.0\\um\x64" /EXPORT:PyInit_cxmlstring build\temp.win-amd64-cpython-313\Release\clib\xmlstring.obj /OUT:build\lib.win-amd64-cpython-313\amara3\cmodules\cxmlstring.cp313-win_amd64.pyd /IMPLIB:build\temp.win-amd64-cpython-313\Release\clib\cxmlstring.cp313-win_amd64.lib
         Creating library build\temp.win-amd64-cpython-313\Release\clib\cxmlstring.cp313-win_amd64.lib and object build\temp.win-amd64-cpython-313\Release\clib\cxmlstring.cp313-win_amd64.exp
      xmlstring.obj : error LNK2001: unresolved external symbol PyUnicode_AS_UNICODE
      build\lib.win-amd64-cpython-313\amara3\cmodules\cxmlstring.cp313-win_amd64.pyd : fatal error LNK1120: 1 unresolved externals
      error: command 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\VC\\Tools\\MSVC\\14.37.32822\\bin\\HostX86\\x64\\link.exe' failed with exit code 1120
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for amara3.xml
Successfully built versa.zextra translate                                                                                                                                                                                                           
Failed to build amara3.xml

It looks like we need just a small adjustment in description file. 
So it would be great if you can merge and release the new version.